### PR TITLE
Saved OAuth settings back to options

### DIFF
--- a/src/PresenceLight/MainWindow.xaml.cs
+++ b/src/PresenceLight/MainWindow.xaml.cs
@@ -485,6 +485,11 @@ namespace PresenceLight
             {
                 return false;
             }
+
+            _options.ClientId = Config.ClientId;
+            _options.TenantId = Config.TenantId;
+            _options.RedirectUri = Config.RedirectUri;
+
             return true;
         }
 


### PR DESCRIPTION
Step is necessary to use the new values user enters into dialog to initialize the MSAL PCA.

FIxes #3