### PR TITLE
Add Custom API Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 | [Phillips Hue Bridge](https://www2.meethue.com/en-us/p/hue-bridge/046677458478)
 | [Phillips Hue Light Bulb](https://www2.meethue.com/en-us/p/hue-white-and-color-ambiance-1-pack-e26/046677548483) |
 | [Any LIFX Light](https://www.lifx.com/pages/all-products) |
+| Any light which can be controlled via a GET or POST call to a web API |
 
 ## Configure Hardware
 - [Configure Hardware](https://github.com/isaacrlevin/PresenceLight/wiki/Configure-Hardware)

--- a/src/PresenceLight.Core/ConfigWrapper.cs
+++ b/src/PresenceLight.Core/ConfigWrapper.cs
@@ -39,5 +39,35 @@ namespace PresenceLight.Core
         public bool IsPhillipsEnabled { get; set; }
 
         public bool IsYeelightEnabled { get; set; }
+
+        public bool IsCustomApiEnabled { get; set; }
+
+        public string? CustomApiAvailableMethod { get; set; }
+
+        public string? CustomApiAvailableUri { get; set; }
+
+        public string? CustomApiBusyMethod { get; set; }
+
+        public string? CustomApiBusyUri { get; set; }
+
+        public string? CustomApiBeRightBackMethod { get; set; }
+
+        public string? CustomApiBeRightBackUri { get; set; }
+
+        public string? CustomApiAwayMethod { get; set; }
+
+        public string? CustomApiAwayUri { get; set; }
+
+        public string? CustomApiDoNotDisturbMethod { get; set; }
+
+        public string? CustomApiDoNotDisturbUri { get; set; }
+
+        public string? CustomApiOfflineMethod { get; set; }
+
+        public string? CustomApiOfflineUri { get; set; }
+
+        public string? CustomApiOffMethod { get; set; }
+
+        public string? CustomApiOffUri { get; set; }
     }
 }

--- a/src/PresenceLight.Core/ConfigWrapper.cs
+++ b/src/PresenceLight.Core/ConfigWrapper.cs
@@ -69,5 +69,7 @@ namespace PresenceLight.Core
         public string? CustomApiOffMethod { get; set; }
 
         public string? CustomApiOffUri { get; set; }
+
+        public double CustomApiTimeout { get; set; }
     }
 }

--- a/src/PresenceLight.Core/Lights/CustomApiService.cs
+++ b/src/PresenceLight.Core/Lights/CustomApiService.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net.Http;
+
+namespace PresenceLight.Core
+{
+    public interface ICustomApiService
+    {
+        Task SetColor(string availability);
+    }
+
+    public class CustomApiService : ICustomApiService
+    {
+        static readonly HttpClient client = new HttpClient();
+
+        private readonly ConfigWrapper _options;
+
+        public CustomApiService(IOptionsMonitor<ConfigWrapper> optionsAccessor)
+        {
+            _options = optionsAccessor.CurrentValue;
+        }
+
+        public CustomApiService(ConfigWrapper options)
+        {
+            _options = options;
+        }
+
+        public async Task SetColor(string availability)
+        {
+            string method = string.Empty;
+            string uri = string.Empty;
+
+            switch (availability)
+            {
+                case "Available":
+                    method = _options.CustomApiAvailableMethod;
+                    uri = _options.CustomApiAvailableUri;
+                    break;
+                case "Busy":
+                    method = _options.CustomApiBusyMethod;
+                    uri = _options.CustomApiBusyUri;
+                    break;
+                case "BeRightBack":
+                    method = _options.CustomApiBeRightBackMethod;
+                    uri = _options.CustomApiBeRightBackUri;
+                    break;
+                case "Away":
+                    method = _options.CustomApiAwayMethod;
+                    uri = _options.CustomApiAwayUri;
+                    break;
+                case "DoNotDisturb":
+                    method = _options.CustomApiDoNotDisturbMethod;
+                    uri = _options.CustomApiDoNotDisturbUri;
+                    break;
+                case "Offline":
+                    method = _options.CustomApiOfflineMethod;
+                    uri = _options.CustomApiOfflineUri;
+                    break;
+                case "Off":
+                    method = _options.CustomApiOffMethod;
+                    uri = _options.CustomApiOffUri;
+                    break;
+                default:
+                    break;
+            }
+
+            if (method != string.Empty && uri != string.Empty)
+            {
+                switch (method)
+                {
+                    case "GET":
+                        try
+                        {
+                            HttpResponseMessage response = await client.GetAsync(uri);
+                            //response.EnsureSuccessStatusCode();
+                            //string responseBody = await response.Content.ReadAsStringAsync();
+
+                            //Console.WriteLine(responseBody);
+                        }
+                        catch (HttpRequestException e)
+                        {
+                            //Console.WriteLine("\nException Caught!");
+                            //Console.WriteLine("Message :{0} ", e.Message);
+                        }
+                        break;
+                    case "POST":
+                        try
+                        {
+                            HttpResponseMessage response = await client.PostAsync(uri, null);
+                            //response.EnsureSuccessStatusCode();
+                            //string responseBody = await response.Content.ReadAsStringAsync();
+
+                            //Console.WriteLine(responseBody);
+                        }
+                        catch (HttpRequestException e)
+                        {
+                            //Console.WriteLine("\nException Caught!");
+                            //Console.WriteLine("Message :{0} ", e.Message);
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/PresenceLight.Worker/AADSettings.json
+++ b/src/PresenceLight.Worker/AADSettings.json
@@ -13,5 +13,7 @@
   "HueIpAddress": "",
   "IconType": "White",
   "IsLIFXEnabled": false,
-  "IsPhillipsEnabled": false
+  "IsPhillipsEnabled": false,
+  "IsCustomApiEnabled": false,
+  "CustomApiTimeout": 10.0
 }

--- a/src/PresenceLight/App.xaml.cs
+++ b/src/PresenceLight/App.xaml.cs
@@ -60,6 +60,7 @@ namespace PresenceLight
             services.AddSingleton<IHueService, HueService>();
             services.AddSingleton<LIFXService, LIFXService>();
             services.AddSingleton<IYeelightService, YeelightService>();
+            services.AddSingleton<ICustomApiService, CustomApiService>();
             services.AddSingleton<LIFXOAuthHelper, LIFXOAuthHelper>();
             services.AddSingleton<MainWindow>();
 

--- a/src/PresenceLight/MainWindow.CustomApi.cs
+++ b/src/PresenceLight/MainWindow.CustomApi.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using LifxCloud.NET.Models;
+using PresenceLight.Telemetry;
+using System.Windows.Navigation;
+
+namespace PresenceLight
+{
+    public partial class MainWindow : Window
+    {
+
+        private void cbIsCustomApiEnabledChanged(object sender, RoutedEventArgs e)
+        {
+            if (Config.IsCustomApiEnabled)
+            {
+                pnlCustomApi.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                pnlCustomApi.Visibility = Visibility.Collapsed;
+            }
+
+            SyncOptions();
+            e.Handled = true;
+        }
+
+        private void customApiMethod_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            ComboBox sourceComboBox = e.Source as ComboBox;
+            ComboBoxItem selectedItem = (ComboBoxItem)sourceComboBox.SelectedItem;
+            string selectedText = selectedItem.Content.ToString();
+
+            switch (sourceComboBox.Name)
+            {
+                case "customApiAvailableMethod":
+                    Config.CustomApiAvailableMethod = selectedText;
+                    break;
+                case "customApiBusyMethod":
+                    Config.CustomApiBusyMethod = selectedText;
+                    break;
+
+                case "customApiBeRightBackMethod":
+                    Config.CustomApiBeRightBackMethod = selectedText;
+                    break;
+                case "customApiAwayMethod":
+                    Config.CustomApiAwayMethod = selectedText;
+                    break;
+                case "customApiDoNotDisturbMethod":
+                    Config.CustomApiDoNotDisturbMethod = selectedText;
+                    break;
+                case "customApiOfflineMethod":
+                    Config.CustomApiOfflineMethod = selectedText;
+                    break;
+                case "customApiOffMethod":
+                    Config.CustomApiOffMethod = selectedText;
+                    break;
+                default:
+                    break;
+            }
+
+            e.Handled = true;
+        }
+
+        private async void btnApiSettingsSave_Click(object sender, RoutedEventArgs e)
+        {
+            await SettingsService.SaveSettings(Config);
+            SyncOptions();
+        }
+
+    }
+
+}

--- a/src/PresenceLight/MainWindow.CustomApi.cs
+++ b/src/PresenceLight/MainWindow.CustomApi.cs
@@ -67,6 +67,7 @@ namespace PresenceLight
         private async void btnApiSettingsSave_Click(object sender, RoutedEventArgs e)
         {
             await SettingsService.SaveSettings(Config);
+            lblCustomApiSaved.Visibility = Visibility.Visible;
             SyncOptions();
         }
 

--- a/src/PresenceLight/MainWindow.xaml
+++ b/src/PresenceLight/MainWindow.xaml
@@ -264,17 +264,23 @@
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="10" />
-                            <RowDefinition Height="40" />
-                            <RowDefinition Height="40" />
-                            <RowDefinition Height="40" />
-                            <RowDefinition Height="40" />
-                            <RowDefinition Height="40" />
-                            <RowDefinition Height="40" />
-                            <RowDefinition Height="40" />
-                            <RowDefinition Height="*" />
+                            <RowDefinition Height="30"/>
+                            <RowDefinition Height="35" />
+                            <RowDefinition Height="35" />
+                            <RowDefinition Height="35" />
+                            <RowDefinition Height="35" />
+                            <RowDefinition Height="35" />
+                            <RowDefinition Height="35" />
+                            <RowDefinition Height="35" />
+                            <RowDefinition Height="35"/>
+                            <RowDefinition Height="35"/>
+                            <RowDefinition/>
                         </Grid.RowDefinitions>
-                        <Label x:Name="customApiAvailableLabel" Content="Available:" Margin="10,6,0,0" Grid.Row="1" VerticalAlignment="Center"/>
+                        <Label x:Name="customApiPreseneceHeader" Content="Presence State" VerticalAlignment="Center" HorizontalAlignment="Center" FontWeight="Bold"/>
+                        <Label x:Name="customApiMethodHeader" Content="API Method" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" FontWeight="Bold"/>
+                        <Label x:Name="customApiUriHeader" Content="API URI" Margin="10,0,0,0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Left" FontWeight="Bold"/>
+
+                        <Label x:Name="customApiAvailableLabel" Content="Available:" Margin="10,0,0,0" Grid.Row="1" VerticalAlignment="Center"/>
                         <ComboBox x:Name="customApiAvailableMethod" HorizontalAlignment="Left" Grid.Row="1" VerticalAlignment="Center" Width="72" Grid.Column="1" Margin="10,0,0,0" SelectionChanged="customApiMethod_SelectionChanged" SelectedValuePath="Content">
                             <ComboBoxItem Content="GET"></ComboBoxItem>
                             <ComboBoxItem Content="POST"></ComboBoxItem>
@@ -322,8 +328,15 @@
                             <ComboBoxItem Content="POST"></ComboBoxItem>
                         </ComboBox>
                         <TextBox x:Name="customApiOffUri" Grid.Row="7" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding CustomApiOffUri}" Grid.Column="2" Margin="10,0,14,0"/>
+<!--
+                        <Label x:Name="lblCustomApiTimeout" Content="API Timeout (s):" Margin="10,0,0,0" Grid.Row="8" VerticalAlignment="Center"/>
+                        <xctk:DecimalUpDown x:Name="customApiTimeout" Grid.Column="1" Grid.Row="8"  FormatString="F0" Value="{Binding CustomApiTimeout}" Height="23"  VerticalAlignment="Center" Increment="1" Maximum="30" Minimum="1" HorizontalAlignment="Left" Width="72" Margin="10,0,0,0" DefaultValue="10" />
+-->
+                        <Label x:Name="lblCustomApiLastResponse" Content="Last Response:" Margin="10,0,0,0" Grid.Row="9" VerticalAlignment="Center"/>
+                        <Label x:Name="customApiLastResponse" Grid.Row="9" VerticalAlignment="Center" Grid.Column="1" Grid.ColumnSpan="2" Margin="10,0,14,0"/>
 
-                        <Button x:Name="btnCustomApiSettingsSave" Content="Save" HorizontalAlignment="Center" Grid.Row="8" VerticalAlignment="Center" Grid.ColumnSpan="3" Height="40" Width="132" Click="btnApiSettingsSave_Click"/>
+                        <Button x:Name="btnCustomApiSettingsSave" Content="Save" HorizontalAlignment="Center" Grid.Row="10" VerticalAlignment="Center" Grid.Column="0" Grid.ColumnSpan="3" Height="40" Width="132" Click="btnApiSettingsSave_Click"/>
+                        <Label Grid.Row="10" Grid.RowSpan="1" Grid.Column="0" Grid.ColumnSpan="3" VerticalAlignment="Center" x:Name="lblCustomApiSaved" HorizontalAlignment="Center" Visibility="Collapsed" Content="Settings Saved" Foreground="Green" Margin="0,60,0,0"/>
                     </Grid>
                 </Grid>
             </TabItem>

--- a/src/PresenceLight/MainWindow.xaml
+++ b/src/PresenceLight/MainWindow.xaml
@@ -241,6 +241,92 @@
                     </Grid>
                 </Grid>
             </TabItem>
+            <TabItem Header="Configure Custom API" >
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="50"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="50"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="50" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid Grid.Column="1" Grid.ColumnSpan="4">
+                        <CheckBox x:Name="cbIsCustomApiEnabled" IsChecked="{Binding IsCustomApiEnabled}" Content="Enable Custom API calls" HorizontalAlignment="Left" Margin="0,20,0,0" VerticalAlignment="Top" Unchecked="cbIsCustomApiEnabledChanged" Checked="cbIsCustomApiEnabledChanged" Grid.Column="1" Grid.ColumnSpan="4" />
+                    </Grid>
+                    <Grid x:Name="pnlCustomApi" Grid.Column="1" Grid.Row="1" Grid.ColumnSpan="3">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="110"/>
+                            <ColumnDefinition Width="100"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="10" />
+                            <RowDefinition Height="40" />
+                            <RowDefinition Height="40" />
+                            <RowDefinition Height="40" />
+                            <RowDefinition Height="40" />
+                            <RowDefinition Height="40" />
+                            <RowDefinition Height="40" />
+                            <RowDefinition Height="40" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Label x:Name="customApiAvailableLabel" Content="Available:" Margin="10,6,0,0" Grid.Row="1" VerticalAlignment="Center"/>
+                        <ComboBox x:Name="customApiAvailableMethod" HorizontalAlignment="Left" Grid.Row="1" VerticalAlignment="Center" Width="72" Grid.Column="1" Margin="10,0,0,0" SelectionChanged="customApiMethod_SelectionChanged" SelectedValuePath="Content">
+                            <ComboBoxItem Content="GET"></ComboBoxItem>
+                            <ComboBoxItem Content="POST"></ComboBoxItem>
+                        </ComboBox>
+                        <TextBox x:Name="customApiAvailableUri" Grid.Row="1" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding CustomApiAvailableUri}" Grid.Column="2" Margin="10,0,14,0"/>
+
+                        <Label x:Name="customApiBusyLabel" Content="Busy:" Margin="10,0,0,0" Grid.Row="2" VerticalAlignment="Center"/>
+                        <ComboBox x:Name="customApiBusyMethod" HorizontalAlignment="Left" Grid.Row="2" VerticalAlignment="Center" Width="72" Grid.Column="1" Margin="10,0,0,0" SelectionChanged="customApiMethod_SelectionChanged" SelectedValuePath="Content">
+                            <ComboBoxItem Content="GET"></ComboBoxItem>
+                            <ComboBoxItem Content="POST"></ComboBoxItem>
+                        </ComboBox>
+                        <TextBox x:Name="customApiBusyUri" Grid.Row="2" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding CustomApiBusyUri}" Grid.Column="2" Margin="10,0,14,0"/>
+
+                        <Label x:Name="customApiBeRightBackLabel" Content="Be Right Back:" Margin="10,0,0,0" Grid.Row="3" VerticalAlignment="Center"/>
+                        <ComboBox x:Name="customApiBeRightBackMethod" HorizontalAlignment="Left" Grid.Row="3" VerticalAlignment="Center" Width="72" Grid.Column="1" Margin="10,0,0,0" SelectionChanged="customApiMethod_SelectionChanged" SelectedValuePath="Content">
+                            <ComboBoxItem Content="GET"></ComboBoxItem>
+                            <ComboBoxItem Content="POST"></ComboBoxItem>
+                        </ComboBox>
+                        <TextBox x:Name="customApiBeRightBackUri" Grid.Row="3" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding CustomApiBeRightBackUri}" Grid.Column="2" Margin="10,0,14,0"/>
+
+                        <Label x:Name="customApiAwayLabel" Content="Away:" Margin="10,0,0,0" Grid.Row="4" VerticalAlignment="Center"/>
+                        <ComboBox x:Name="customApiAwayMethod" HorizontalAlignment="Left" Grid.Row="4" VerticalAlignment="Center" Width="72" Grid.Column="1" Margin="10,0,0,0" SelectionChanged="customApiMethod_SelectionChanged" SelectedValuePath="Content">
+                            <ComboBoxItem Content="GET"></ComboBoxItem>
+                            <ComboBoxItem Content="POST"></ComboBoxItem>
+                        </ComboBox>
+                        <TextBox x:Name="customApiAwayUri" Grid.Row="4" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding CustomApiAwayUri}" Grid.Column="2" Margin="10,0,14,0"/>
+
+                        <Label x:Name="customApiDoNotDisturbLabel" Content="Do Not Disturb:" Margin="10,0,0,0" Grid.Row="5" VerticalAlignment="Center"/>
+                        <ComboBox x:Name="customApiDoNotDisturbMethod" HorizontalAlignment="Left" Grid.Row="5" VerticalAlignment="Center" Width="72" Grid.Column="1" Margin="10,0,0,0" SelectionChanged="customApiMethod_SelectionChanged" SelectedValuePath="Content">
+                            <ComboBoxItem Content="GET"></ComboBoxItem>
+                            <ComboBoxItem Content="POST"></ComboBoxItem>
+                        </ComboBox>
+                        <TextBox x:Name="customApiDoNotDisturbUri" Grid.Row="5" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding CustomApiDoNotDisturbUri}" Grid.Column="2" Margin="10,0,14,0"/>
+
+                        <Label x:Name="customApiOfflineLabel" Content="Offline:" Margin="10,0,0,0" Grid.Row="6" VerticalAlignment="Center"/>
+                        <ComboBox x:Name="customApiOfflineMethod" HorizontalAlignment="Left" Grid.Row="6" VerticalAlignment="Center" Width="72" Grid.Column="1" Margin="10,0,0,0" SelectionChanged="customApiMethod_SelectionChanged" SelectedValuePath="Content">
+                            <ComboBoxItem Content="GET"></ComboBoxItem>
+                            <ComboBoxItem Content="POST"></ComboBoxItem>
+                        </ComboBox>
+                        <TextBox x:Name="customApiOfflineUri" Grid.Row="6" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding CustomApiOfflineUri}" Grid.Column="2" Margin="10,0,14,0"/>
+
+                        <Label x:Name="customApiOffLabel" Content="Off:" Margin="10,0,0,0" Grid.Row="7" VerticalAlignment="Center"/>
+                        <ComboBox x:Name="customApiOffMethod" HorizontalAlignment="Left" Grid.Row="7" VerticalAlignment="Center" Width="72" Grid.Column="1" Margin="10,0,0,0" SelectionChanged="customApiMethod_SelectionChanged" SelectedValuePath="Content">
+                            <ComboBoxItem Content="GET"></ComboBoxItem>
+                            <ComboBoxItem Content="POST"></ComboBoxItem>
+                        </ComboBox>
+                        <TextBox x:Name="customApiOffUri" Grid.Row="7" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding CustomApiOffUri}" Grid.Column="2" Margin="10,0,14,0"/>
+
+                        <Button x:Name="btnCustomApiSettingsSave" Content="Save" HorizontalAlignment="Center" Grid.Row="8" VerticalAlignment="Center" Grid.ColumnSpan="3" Height="40" Width="132" Click="btnApiSettingsSave_Click"/>
+                    </Grid>
+                </Grid>
+            </TabItem>
             <TabItem Header="Settings" >
                 <Grid>
                     <Grid.ColumnDefinitions>

--- a/src/PresenceLight/MainWindow.xaml.cs
+++ b/src/PresenceLight/MainWindow.xaml.cs
@@ -279,11 +279,18 @@ namespace PresenceLight
 
             if (Config.IsCustomApiEnabled)
             {
-                await _customApiService.SetColor(color);
+                string response = await _customApiService.SetColor(color);
+                customApiLastResponse.Content = response;
+                if (response.StartsWith("Error:"))
+                {
+                    customApiLastResponse.Foreground = new SolidColorBrush(Colors.Red);
+                }
+                else
+                {
+                    customApiLastResponse.Foreground = new SolidColorBrush(Colors.Green);
+                }
             }
         }
-
-
 
         private async void SignOutButton_Click(object sender, RoutedEventArgs e)
         {

--- a/src/PresenceLight/MainWindow.xaml.cs
+++ b/src/PresenceLight/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.Graph;
 using Microsoft.Identity.Client;
 using PresenceLight.Core;
@@ -33,6 +33,7 @@ namespace PresenceLight
 
         private IYeelightService _yeelightService;
         private IHueService _hueService;
+        private ICustomApiService _customApiService;
         private LIFXOAuthHelper _lIFXOAuthHelper;
         private LIFXService _lifxService;
         private GraphServiceClient _graphServiceClient;
@@ -40,7 +41,7 @@ namespace PresenceLight
         private WindowState lastWindowState;
 
         #region Init
-        public MainWindow(IGraphService graphService, IHueService hueService, LIFXService lifxService, IYeelightService yeelightService, IOptionsMonitor<ConfigWrapper> optionsAccessor, LIFXOAuthHelper lifxOAuthHelper)
+        public MainWindow(IGraphService graphService, IHueService hueService, LIFXService lifxService, IYeelightService yeelightService, ICustomApiService customApiService, IOptionsMonitor<ConfigWrapper> optionsAccessor, LIFXOAuthHelper lifxOAuthHelper)
         {
             InitializeComponent();
 
@@ -52,6 +53,7 @@ namespace PresenceLight
             _yeelightService = yeelightService;
             _lifxService = lifxService;
             _hueService = hueService;
+            _customApiService = customApiService;
             _options = optionsAccessor.CurrentValue;
             _lIFXOAuthHelper = lifxOAuthHelper;
             LoadSettings().ContinueWith(
@@ -160,6 +162,23 @@ namespace PresenceLight
                 getTokenLink.Visibility = Visibility.Collapsed;
                 pnlLIFX.Visibility = Visibility.Collapsed;
             }
+
+            if (Config.IsCustomApiEnabled)
+            {
+                pnlCustomApi.Visibility = Visibility.Visible;
+                customApiAvailableMethod.SelectedValue = Config.CustomApiAvailableMethod;
+                customApiBusyMethod.SelectedValue = Config.CustomApiBusyMethod;
+                customApiBeRightBackMethod.SelectedValue = Config.CustomApiBeRightBackMethod;
+                customApiAwayMethod.SelectedValue = Config.CustomApiAwayMethod;
+                customApiDoNotDisturbMethod.SelectedValue = Config.CustomApiDoNotDisturbMethod;
+                customApiOfflineMethod.SelectedValue = Config.CustomApiOfflineMethod;
+                customApiOffMethod.SelectedValue = Config.CustomApiOffMethod;
+                SyncOptions();
+            }
+            else
+            {
+                pnlCustomApi.Visibility = Visibility.Collapsed;
+            }
         }
         #endregion
 
@@ -256,6 +275,11 @@ namespace PresenceLight
             if(Config.IsYeelightEnabled && !string.IsNullOrEmpty(Config.SelectedYeeLightId))
             {
                 await _yeelightService.SetColor(color, Config.SelectedYeeLightId);
+            }
+
+            if (Config.IsCustomApiEnabled)
+            {
+                await _customApiService.SetColor(color);
             }
         }
 
@@ -548,5 +572,7 @@ namespace PresenceLight
             await SettingsService.SaveSettings(Config);
         }
         #endregion
+
+
     }
 }


### PR DESCRIPTION
Adds a 'Custom API' settings page, allowing user-specified GET or POST URIs to be configured for each Teams presence state.  When the presence changes the corresponding URI will be called.

![custom_api](https://user-images.githubusercontent.com/23322579/83973086-de5a8580-a8db-11ea-979b-58934a693a75.PNG)

I've tested it with a local web service and am now using it with IFTTT WebHooks to control my 'Magic Home' LED light strip.

It's not quite as good as I would like, but it works well for me. I'd like to make the HTTP timeout configurable but I was struggling to work out exactly how to get a configuration option value into service constructor.  I'll re-visit that on another rainy day.

I'm pretty happy with my Teams 'BusyShelves'.

![IMG_20200605_235632](https://user-images.githubusercontent.com/23322579/83973109-1235ab00-a8dc-11ea-94f4-41c569a72d1e.jpg)

