### PR TITLE
Fixed variable used to set Yeelight color

### DIFF
--- a/src/PresenceLight.Core/Lights/YeelightService.cs
+++ b/src/PresenceLight.Core/Lights/YeelightService.cs
@@ -210,7 +210,7 @@ namespace PresenceLight.Core
                     }
                 }
 
-                var rgb = new RGBColor(availability);
+                var rgb = new RGBColor(color);
                 await device.SetRGBColor((int)rgb.R, (int)rgb.G, (int)rgb.B);
                 return;
             }


### PR DESCRIPTION
`availability` was the text of the status which cause an exception.
`busy` is the color hex