### PR TITLE
Fix Custom API Save Button Typo

### DIFF
--- a/src/PresenceLight.Worker/Pages/CustomApiSetup.razor
+++ b/src/PresenceLight.Worker/Pages/CustomApiSetup.razor
@@ -62,7 +62,7 @@
                         <br />
                         <br />
 
-                        <button class="btn btn-primary" @onclick="Save">Save LIFX Settings</button>
+                        <button class="btn btn-primary" @onclick="Save">Save Custom API Settings</button>
 
                         <br />
                         <br />


### PR DESCRIPTION
Fixes a small typo in the save button on the Custom API page in the web version.