### PR TITLE
(#523) Remove whitespace from description section

### DIFF
--- a/.chocolatey/PresenceLight.nuspec
+++ b/.chocolatey/PresenceLight.nuspec
@@ -15,14 +15,14 @@
     <iconUrl>https://rawcdn.githack.com/isaacrlevin/PresenceLight/2c388db6a155cf7bbc8b12578222e0609d147ee0/Icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
-      PresenceLight is a solution to broadcast your various statuses to a Phillips Hue or LIFX light bulb.
-      Some statuses you can broadcast are: your availability in Microsoft Teams, your current Windows 10 theme, and a theme or color of your choosing.
+PresenceLight is a solution to broadcast your various statuses to a Phillips Hue or LIFX light bulb.
+Some statuses you can broadcast are: your availability in Microsoft Teams, your current Windows 10 theme, and a theme or color of your choosing.
 
-      ## Package Parameters
+## Package Parameters
 
-      - x86: Force x86 installation of PresenceLight
-      - x64: Force x64 installation of PresenceLight (default)
-      - InstallDir: Change installation directory of PresenceLight. Default is "$env:APPDATA\PresenceLight"
+- x86: Force x86 installation of PresenceLight
+- x64: Force x64 installation of PresenceLight (default)
+- InstallDir: Change installation directory of PresenceLight. Default is "$env:APPDATA\PresenceLight"
     </description>
     <summary>Broadcasts colors to various Smart Lights</summary>
     <releaseNotes>https://github.com/isaacrlevin/PresenceLight/releases</releaseNotes>


### PR DESCRIPTION
This will result in the markdown rendering correctly on the community.chocolatey.org website.

Fixes #523 