### PR TITLE
(#532) Halt any processes before operations

### DIFF
--- a/.chocolatey/tools/ChocolateyBeforeModify.ps1
+++ b/.chocolatey/tools/ChocolateyBeforeModify.ps1
@@ -1,0 +1,3 @@
+# Make sure to kill any presencelight processes before attempting an
+# uninstall or upgrade of PresenceLight
+Get-Process presencelight* -ErrorAction SilentlyContinue | Stop-Process

--- a/.chocolatey/tools/ChocolateyInstall.ps1
+++ b/.chocolatey/tools/ChocolateyInstall.ps1
@@ -1,5 +1,10 @@
 $ErrorActionPreference  = 'Stop';
 
+# Make sure to kill any presencelight processes before attempting an
+# installation. This covers the case that PresenceLight is currently
+# installed outside of Chocolatey
+Get-Process presencelight* -ErrorAction SilentlyContinue | Stop-Process
+
 $WindowsVersion=[Environment]::OSVersion.Version
 if ($WindowsVersion.Major -ne "10") {
   throw "This package requires Windows 10."

--- a/.chocolatey/tools/ChocolateyUninstall.ps1
+++ b/.chocolatey/tools/ChocolateyUninstall.ps1
@@ -1,3 +1,5 @@
+# This logic can be removed after a couple of package version releases, since
+# this will be handled in the ChocolateyBeforeModify.ps1 going forward
 $light = Get-process presencelight*
 
 if($light){


### PR DESCRIPTION
Make sure to halt any presencelight processes before performing any
operations. This will ensure that no locked files prevent the operation
from completing. Some duplicated code here can be removed once a couple
package versions have been released.

Fixes #532 