### PR TITLE
Added new baud rate for WLED default

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 | LIFX |
 | Yeelight |
 | Philips Wiz |
+| [WLED](https://kno.wled.ge/) (via serial or web API) |
 | Any light which can be controlled via a GET or POST call to a web API |
 
 ## Docs

--- a/src/PresenceLight.Razor/Components/Pages/LocalSerialHostSetup.razor
+++ b/src/PresenceLight.Razor/Components/Pages/LocalSerialHostSetup.razor
@@ -54,7 +54,7 @@
                                                     @foreach(var port in appState.LocalSerialHosts)
                                                     {
                                                         <option value="@port">@port</option>
-                                                    }                                                
+                                                    }
                                                 </select>
                                             </MudItem>
                                         }
@@ -72,6 +72,7 @@
                                                     <option value="19200">19200</option>
                                                     <option value="38400">38400</option>
                                                     <option value="57600">57600</option>
+                                                    <option value="115200">115200</option>
                                                 </select>
                                             </MudItem>
                                         }


### PR DESCRIPTION
This PR adds an additional baud rate to the custom serial connection.  This is the default rate which WLED uses: https://kno.wled.ge/interfaces/serial/

Without this I need a small local shim microservice and use the custom rest calls so having this would be awesome :)

*Note:* I have not tested this code locally as I am not set up with the client ID and secret.  I have sent an email and can test it locally if I get that info.