### PR TITLE
Add email to user information display

### DIFF
--- a/src/DesktopClient/PresenceLight/MainWindow.xaml.cs
+++ b/src/DesktopClient/PresenceLight/MainWindow.xaml.cs
@@ -490,7 +490,7 @@ private async Task InteractWithLights()
             {
                 if (_appState.User == null || string.IsNullOrEmpty(_appState.User.DisplayName))
                 {
-                    var (profile, presence) = await _mediator.Send(new Core.GraphServices.GetProfileAndPresenceCommand());
+                    var (profile, presence, email) = await _mediator.Send(new Core.GraphServices.GetProfileAndPresenceCommand());
 
                     var photo = await GetPhoto();
 
@@ -506,6 +506,8 @@ private async Task InteractWithLights()
                         MapUI(presence);
                         _appState.SetUserInfo(profile, presence, $"data:image/gif;base64,{Convert.ToBase64String(photo)}");
                     }
+
+                    _appState.Email = email;
                 }
                 await Task.Delay(Convert.ToInt32(_appState.Config.LightSettings.PollingInterval * 1000));
 

--- a/src/PresenceLight.Core/Configuration/AppState.cs
+++ b/src/PresenceLight.Core/Configuration/AppState.cs
@@ -116,6 +116,11 @@ namespace PresenceLight.Core
         public BaseConfig Config { get; set; } = new BaseConfig();
 
         /// <summary>
+        /// Gets or sets the user's email.
+        /// </summary>
+        public string Email { get; set; }
+
+        /// <summary>
         /// Sets the configuration.
         /// </summary>
         /// <param name="config">The configuration to set.</param>
@@ -135,6 +140,7 @@ namespace PresenceLight.Core
             User = user;
             Presence = presence;
             ProfileImage = photo;
+            Email = user?.Mail;
             NotifyStateChanged();
         }
 

--- a/src/PresenceLight.Core/GraphServices/GetProfileAndPresenceHandler.cs
+++ b/src/PresenceLight.Core/GraphServices/GetProfileAndPresenceHandler.cs
@@ -1,0 +1,24 @@
+﻿using MediatR;
+using Microsoft.Graph.Models;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PresenceLight.Core.GraphServices
+{
+    internal class GetProfileAndPresenceHandler : IRequestHandler<GetProfileAndPresenceCommand, (User User, Presence Presence, string Email)>
+    {
+        GraphWrapper _graph;
+
+        public GetProfileAndPresenceHandler(GraphWrapper graph)
+        {
+            _graph = graph;
+        }
+
+        public async Task<(User User, Presence Presence, string Email)> Handle(GetProfileAndPresenceCommand command, CancellationToken cancellationToken)
+        {
+            var (user, presence) = await _graph.GetProfileAndPresence(cancellationToken);
+            var email = user.Mail;
+            return (user, presence, email);
+        }
+    }
+}

--- a/src/PresenceLight.Razor/Components/Shared/LoginDisplay.razor
+++ b/src/PresenceLight.Razor/Components/Shared/LoginDisplay.razor
@@ -7,7 +7,7 @@
     {
         <MudMenu AnchorOrigin="Origin.CenterCenter" Dense="true" Class="mt-1 ml-4">
             <ActivatorContent>
-                <MudText Typo="Typo.body2" Class="px-4 py-2"> Hello, @appState.User.DisplayName!</MudText>
+                <MudText Typo="Typo.body2" Class="px-4 py-2"> Hello, @appState.User.DisplayName! (@appState.Email)</MudText>
             </ActivatorContent>
             <ChildContent>
                 <MudListItem Text="Logout" Icon="@Icons.Material.Filled.Logout" OnClick="SignOut" />


### PR DESCRIPTION
Add user's email to the UI of PresenceLight.

* Add a new property `Email` to `AppState` in `src/PresenceLight.Core/Configuration/AppState.cs` to store the user's email.
* Create `GetProfileAndPresenceHandler` in `src/PresenceLight.Core/GraphServices/GetProfileAndPresenceHandler.cs` to extract and return the user's email.
* Modify `MainWindow.xaml.cs` in `src/DesktopClient/PresenceLight/MainWindow.xaml.cs` to retrieve and store the user's email in the `AppState`.
* Update `LoginDisplay.razor` in `src/PresenceLight.Razor/Components/Shared/LoginDisplay.razor` to display the user's email along with their name.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/isaacrlevin/presencelight?shareId=cef906c2-a526-47a4-a778-65dd1952420d).