### PR TITLE
Update project to .NET 9

### DIFF
--- a/src/DesktopClient/PresenceLight.Package/PresenceLight.Package.wapproj
+++ b/src/DesktopClient/PresenceLight.Package/PresenceLight.Package.wapproj
@@ -86,7 +86,7 @@
     <Exec Command="$(NpeExecCmd)" />
     <Message Text="Built ref " />
     <ItemGroup>
-      <TheFiles Include="..\PresenceLight\bin\$(Configuration)\net8.0-windows10.0.19041\win-$(Platform)\publish\**\*.*" />
+      <TheFiles Include="..\PresenceLight\bin\$(Configuration)\net9.0-windows10.0.19041\win-$(Platform)\publish\**\*.*" />
       <TheFiles TargetPath="PresenceLight\%(RecursiveDir)%(Filename)%(Extension)" />
       <File Include="@(TheFiles)">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/DesktopClient/PresenceLight/PresenceLight.csproj
+++ b/src/DesktopClient/PresenceLight/PresenceLight.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>PresenceLight</AssemblyName>
     <Title>PresenceLight</Title>

--- a/src/DesktopClient/PresenceLight/Properties/PublishProfiles/WinARM64.pubxml
+++ b/src/DesktopClient/PresenceLight/Properties/PublishProfiles/WinARM64.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
-    <TargetFramework>net8.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041</TargetFramework>
     <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>

--- a/src/DesktopClient/PresenceLight/Properties/PublishProfiles/WinX64.pubxml
+++ b/src/DesktopClient/PresenceLight/Properties/PublishProfiles/WinX64.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <TargetFramework>net8.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>

--- a/src/DesktopClient/PresenceLight/Properties/PublishProfiles/WinX86.pubxml
+++ b/src/DesktopClient/PresenceLight/Properties/PublishProfiles/WinX86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <TargetFramework>net8.0-windows10.0.19041</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.19041</TargetFramework>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>

--- a/src/PresenceLight.Core/PresenceLight.Core.csproj
+++ b/src/PresenceLight.Core/PresenceLight.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>annotations</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/PresenceLight.Razor/PresenceLight.Razor.csproj
+++ b/src/PresenceLight.Razor/PresenceLight.Razor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
 

--- a/src/PresenceLight.Web/PresenceLight.Web.csproj
+++ b/src/PresenceLight.Web/PresenceLight.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>PresenceLight</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Upgrade the project from .NET 8 to .NET 9.

* **PresenceLight.csproj**: Update `TargetFramework` to `net9.0-windows10.0.19041`.
* **PresenceLight.Package.wapproj**: Update `TargetFramework` to `net9.0` and `NpeExecCmd` property to use `net9.0-windows10.0.19041`.
* **WinARM64.pubxml, WinX64.pubxml, WinX86.pubxml**: Update `TargetFramework` to `net9.0-windows10.0.19041`.
* **PresenceLight.Core.csproj**: Update `TargetFramework` to `net9.0`.
* **PresenceLight.Razor.csproj**: Update `TargetFramework` to `net9.0`.
* **PresenceLight.Web.csproj**: Update `TargetFramework` to `net9.0`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/isaacrlevin/presencelight?shareId=XXXX-XXXX-XXXX-XXXX).